### PR TITLE
Feature/flatten nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,22 @@
-﻿### 0.1.0
-- Supporting `children`.
+### 0.2.0
+* Flatten legacy fields, so `data` and `config` (and their more modern `filterConfig` and `resultConfig` aliases) are merged into the nodes so types can safely ignore the distinction
+
+### 0.1.0
+* Supporting `children`.
 
 ### 0.0.5
-- Ecosystem And Resources readme update (version bump for npm pubishing)
+* Ecosystem And Resources readme update (version bump for npm pubishing)
 
 ### 0.0.4
-- Pass getProvider and getSchema to result functions
+* Pass getProvider and getSchema to result functions
 
 ### 0.0.3
-- Fixed some core bugs, added better tests, and moved to async/await
+* Fixed some core bugs, added better tests, and moved to async/await
 
 ### 0.0.2
 
-- Add CI configuration and other developer tooling
+* Add CI configuration and other developer tooling
 
 ### 0.0.1
 
-- Initial release
+* Initial release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contexture",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "The Contexture (aka ContextTree) Core",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,15 @@ let makeObjectsSafe = (item, parent) =>
     item
   )
 
+let extendAllOn = _.extendAll.convert({ immutable: false })
+let flattenLegacyFields = item => extendAllOn([
+    item,
+    item.config,
+    item.filterConfig,
+    item.data,
+    item.resultConfig,
+  ])
+
 let runTypeProcessor = _.curry(
   async (getProvider, processor, item, ...args) => {
     try {
@@ -54,6 +63,7 @@ module.exports = _.curryN(
     try {
       await processStep([
         makeObjectsSafe,
+        flattenLegacyFields,
         materializePaths,
         async item => {
           let hasValue = await runProcessor('hasValue', item)

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,8 @@ let makeObjectsSafe = (item, parent) =>
   )
 
 let extendAllOn = _.extendAll.convert({ immutable: false })
-let flattenLegacyFields = item => extendAllOn([
+let flattenLegacyFields = item =>
+  extendAllOn([
     item,
     item.config,
     item.filterConfig,


### PR DESCRIPTION
> [<img alt="daedalus28" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/daedalus28) **Authored by [daedalus28](https://github.com/daedalus28)**
_<time datetime="2017-12-19T21:38:36Z" title="Tuesday, December 19th 2017, 4:38:36 pm -05:00">Dec 19, 2017</time>_
_Merged <time datetime="2017-12-19T21:46:28Z" title="Tuesday, December 19th 2017, 4:46:28 pm -05:00">Dec 19, 2017</time>_
---

Flatten legacy fields, so `data` and `config` (and their more modern `filterConfig` and `resultConfig` aliases) are merged into the nodes so types can safely ignore the distinction